### PR TITLE
Used shared preferences to save user input

### DIFF
--- a/lib/src/providers/user_age_provider.dart
+++ b/lib/src/providers/user_age_provider.dart
@@ -1,16 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class UserAgeProvider extends ChangeNotifier {
   int userAge;
 
   UserAgeProvider({
     this.userAge = 0,
-  });
+  }) {
+    loadUserAge();
+  }
 
-  void setUserAge({
-    required int newAge,
-  }) async {
+  /// Load user's age from SharedPreferences
+  Future<void> loadUserAge() async {
+    final prefs = await SharedPreferences.getInstance();
+    userAge = prefs.getInt('userAge') ?? 0;
+    notifyListeners();
+  }
+
+  /// Save user's age to SharedPreferences
+  Future<void> setUserAge({required int newAge}) async{
     userAge = newAge;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('userAge', newAge);
     notifyListeners();
   }
 }


### PR DESCRIPTION
This update restores the ability to persist the user's age across app sessions using SharedPreferences.

Changes Made in user_age_provider:

1. Added loadUserAge() to fetch the user's saved age from SharedPreferences during provider initialisation.
2. Updated setUserAge() to save the user's age to SharedPreferences whenever it is updated.
3. Ensured notifyListeners() is called after state changes to update dependent widgets.