### PR TITLE
Storing both age and display prefs

### DIFF
--- a/lib/src/providers/user_age_provider.dart
+++ b/lib/src/providers/user_age_provider.dart
@@ -1,16 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class UserAgeProvider extends ChangeNotifier {
   int userAge;
 
   UserAgeProvider({
     this.userAge = 0,
-  });
+  }) {
+    loadUserAge();
+  }
 
-  void setUserAge({
-    required int newAge,
-  }) async {
+  /// Load user's age from SharedPreferences
+  Future<void> loadUserAge() async {
+    final prefs = await SharedPreferences.getInstance();
+    userAge = prefs.getInt('userAge') ?? 0;
+    notifyListeners();
+  }
+
+  /// Save user's age to SharedPreferences
+  Future<void> setUserAge({required int newAge}) async{
     userAge = newAge;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('userAge', newAge);
     notifyListeners();
   }
 }

--- a/lib/src/providers/user_display_prefs_provider.dart
+++ b/lib/src/providers/user_display_prefs_provider.dart
@@ -1,17 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:memento_mori/src/utils/enums.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class UserDisplayPrefsProvider extends ChangeNotifier {
   UserDisplayPreferences userDisplayPreference;
 
   UserDisplayPrefsProvider({
     this.userDisplayPreference = UserDisplayPreferences.days,
-  });
+  }) {
+    loadUserDisplay();
+  }
 
-  void setUserDisplayPref({
-    required UserDisplayPreferences newPref,
-  }) async {
+  /// Load display preference from SharedPreferences
+  Future<void> loadUserDisplay() async{
+    final prefs = await SharedPreferences.getInstance();
+    String? savedPref = prefs.getString('userDisplayPreference');
+    if (savedPref != null) {
+      userDisplayPreference = UserDisplayPreferences.values.firstWhere(
+        (e) => e.toString() == savedPref,
+        orElse: () => UserDisplayPreferences.days,
+      );
+      notifyListeners();
+    }
+  }
+
+  Future<void> setUserDisplayPref({required UserDisplayPreferences newPref}) async{
     userDisplayPreference = newPref;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('userDisplayPreference', newPref.toString());
     notifyListeners();
   }
 }


### PR DESCRIPTION
Changes were made to both files within the provider folder.
This update introduces persistent storage for both user age and display preferences (days, weeks, months, years) using SharedPreferences. Both age and display prefs were handled using a load method and a set method, and finally calling the notifyListener method to update the dependent widget.